### PR TITLE
feat: add setup-labels script, settings template, and SSH fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ If you're a Claude Code agent asked to optimize a project:
 ```
 your-project/
 ├── .claude/
-│   └── skills/
-│       ├── claim-issue      # Claim issue + create branch (1 API call)
-│       ├── check-workflow   # Validate workflow state (1 API call)
-│       ├── submit-pr        # Create PR + update labels (1 API call)
-│       └── README.md
+│   ├── skills/
+│   │   ├── claim-issue      # Claim issue + create branch (1 API call)
+│   │   ├── check-workflow   # Validate workflow state (1 API call)
+│   │   ├── submit-pr        # Create PR + update labels (1 API call)
+│   │   └── README.md
+│   └── settings.local.json  # Pre-configured Claude Code permissions
 └── docs/
     ├── QUICK-REFERENCE.md   # Fast navigation for agents
     ├── FAQ-AGENTS.md        # Pre-answered questions
@@ -106,6 +107,9 @@ claude-workflow-toolkit/
 │   │   ├── submit-pr.sh.template
 │   │   └── README.md.template
 │   │
+│   ├── .claude/
+│   │   └── settings.local.json.template  # Claude Code permissions
+│   │
 │   └── docs/                   # Documentation templates
 │       ├── QUICK-REFERENCE.md.template
 │       ├── FAQ-AGENTS.md.template
@@ -122,7 +126,21 @@ claude-workflow-toolkit/
 │   └── applied/               # Example generated output
 │
 └── scripts/
+    ├── setup-labels.sh        # Create required GitHub labels
     └── validate-templates.sh  # Template syntax validator
+```
+
+## Setup Scripts
+
+### `scripts/setup-labels.sh`
+
+Creates the required GitHub labels in your repository:
+- **Workflow labels**: `agent-ready`, `in-progress`, `needs-review`, `blocked`
+- **Phase labels**: `phase-0` through `phase-6`
+- **Type labels**: `bug`, `enhancement`, `documentation`
+
+```bash
+./scripts/setup-labels.sh
 ```
 
 ## Why Use This?

--- a/SKILL.md
+++ b/SKILL.md
@@ -143,16 +143,29 @@ After applying, the target project will have:
 
 ```
 target-project/
-├── {{SKILLS_DIR}}/
-│   ├── claim-issue      # Claim issue + create branch
-│   ├── check-workflow   # Validate workflow state
-│   ├── submit-pr        # Create PR + update labels
-│   └── README.md        # Skills documentation
+├── .claude/
+│   ├── skills/
+│   │   ├── claim-issue      # Claim issue + create branch
+│   │   ├── check-workflow   # Validate workflow state
+│   │   ├── submit-pr        # Create PR + update labels
+│   │   └── README.md        # Skills documentation
+│   └── settings.local.json  # Pre-configured Claude Code permissions
 └── {{DOCS_DIR}}/
     ├── QUICK-REFERENCE.md   # Navigation hub
     ├── FAQ-AGENTS.md        # Pre-answered questions
     └── CODEBASE-MAP.md      # Annotated directory structure
 ```
+
+### Optional: Setup GitHub Labels
+
+Before using the workflow, the target repository needs the required labels. Run the setup script from this toolkit in the target repo:
+
+```bash
+# From target project directory
+/path/to/claude-workflow-toolkit/scripts/setup-labels.sh
+```
+
+This creates: `agent-ready`, `in-progress`, `needs-review`, `blocked`, `phase-0` through `phase-6`, and type labels.
 
 ## Maintenance
 
@@ -182,3 +195,8 @@ Skills should be in `{{SKILLS_DIR}}/` directory. Verify:
 1. Files exist and are executable
 2. Files have no `.sh` extension (just `claim-issue`, not `claim-issue.sh`)
 3. Claude Code is restarted after adding skills
+
+### SSH authentication fails
+The skill templates include automatic SSH/HTTPS fallback. If SSH fails, they'll attempt to use `gh auth setup-git` to configure HTTPS authentication. Ensure:
+1. GitHub CLI is authenticated: `gh auth status`
+2. If using SSH, keys are properly configured: `ssh -T git@github.com`

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Setup required GitHub labels for Claude Code workflow
+# Usage: ./scripts/setup-labels.sh
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo "Setting up GitHub labels for Claude Code workflow..."
+echo ""
+
+# Check gh CLI is available
+if ! command -v gh &> /dev/null; then
+    echo -e "${RED}Error: GitHub CLI (gh) is required${NC}"
+    echo "Install from: https://cli.github.com/"
+    exit 1
+fi
+
+# Check we're in a git repo
+if ! git rev-parse --git-dir &> /dev/null; then
+    echo -e "${RED}Error: Not in a git repository${NC}"
+    exit 1
+fi
+
+# Workflow labels
+declare -A WORKFLOW_LABELS=(
+    ["agent-ready"]="Task ready for agent work:#0E8A16"
+    ["in-progress"]="Agent actively working:#FBCA04"
+    ["needs-review"]="PR created, awaiting review:#1D76DB"
+    ["blocked"]="Waiting on dependency:#B60205"
+)
+
+# Phase labels (0-6)
+declare -A PHASE_LABELS=(
+    ["phase-0"]="Foundation phase:#C5DEF5"
+    ["phase-1"]="Phase 1:#C5DEF5"
+    ["phase-2"]="Phase 2:#C5DEF5"
+    ["phase-3"]="Phase 3:#C5DEF5"
+    ["phase-4"]="Phase 4:#C5DEF5"
+    ["phase-5"]="Phase 5:#C5DEF5"
+    ["phase-6"]="Phase 6:#C5DEF5"
+)
+
+# Type labels
+declare -A TYPE_LABELS=(
+    ["bug"]="Something isn't working:#D73A4A"
+    ["enhancement"]="New feature or request:#A2EEEF"
+    ["documentation"]="Documentation improvements:#0075CA"
+)
+
+create_label() {
+    local name="$1"
+    local desc_color="$2"
+    local description="${desc_color%%:*}"
+    local color="${desc_color##*:#}"
+
+    # Check if label exists
+    if gh label list --json name -q ".[].name" | grep -q "^${name}$"; then
+        echo -e "  ${YELLOW}EXISTS${NC} $name"
+    else
+        if gh label create "$name" --description "$description" --color "$color" 2>/dev/null; then
+            echo -e "  ${GREEN}CREATED${NC} $name"
+        else
+            echo -e "  ${RED}FAILED${NC} $name"
+        fi
+    fi
+}
+
+echo -e "${BLUE}Workflow Labels${NC}"
+for label in "${!WORKFLOW_LABELS[@]}"; do
+    create_label "$label" "${WORKFLOW_LABELS[$label]}"
+done
+
+echo ""
+echo -e "${BLUE}Phase Labels${NC}"
+for label in "${!PHASE_LABELS[@]}"; do
+    create_label "$label" "${PHASE_LABELS[$label]}"
+done
+
+echo ""
+echo -e "${BLUE}Type Labels${NC}"
+for label in "${!TYPE_LABELS[@]}"; do
+    create_label "$label" "${TYPE_LABELS[$label]}"
+done
+
+echo ""
+echo -e "${GREEN}Label setup complete!${NC}"
+echo ""
+echo "Workflow labels:"
+echo "  agent-ready   → Task available for agents"
+echo "  in-progress   → Agent working on it"
+echo "  needs-review  → PR created"
+echo "  blocked       → Waiting on something"

--- a/templates/.claude/settings.local.json.template
+++ b/templates/.claude/settings.local.json.template
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude/settings.schema.json",
+  "permissions": {
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh label list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh auth setup-git:*)",
+      "Bash(./.claude/skills/claim-issue:*)",
+      "Bash(./.claude/skills/check-workflow:*)",
+      "Bash(./.claude/skills/submit-pr:*)",
+      "Bash({{TEST_COMMAND}}:*)",
+      "Bash({{LINT_COMMAND}}:*)"
+    ],
+    "deny": []
+  }
+}

--- a/templates/skills/claim-issue.sh.template
+++ b/templates/skills/claim-issue.sh.template
@@ -68,11 +68,22 @@ gh issue edit "$ISSUE" --remove-label "agent-ready" --add-label "in-progress" 2>
     gh issue edit "$ISSUE" --add-label "in-progress"
 }
 
+# Helper function for SSH/HTTPS fallback
+git_with_fallback() {
+    local cmd="$1"
+    shift
+    if ! git "$cmd" "$@" 2>/dev/null; then
+        echo "SSH failed, trying HTTPS via gh auth..."
+        gh auth setup-git 2>/dev/null || true
+        git "$cmd" "$@"
+    fi
+}
+
 # Create and checkout branch
 echo "Creating branch..."
-git fetch origin {{DEFAULT_BRANCH}} 2>/dev/null || true
+git_with_fallback fetch origin {{DEFAULT_BRANCH}} || git_with_fallback fetch origin main || true
 git checkout {{DEFAULT_BRANCH}} 2>/dev/null || git checkout main
-git pull origin {{DEFAULT_BRANCH}} 2>/dev/null || git pull origin main
+git_with_fallback pull origin {{DEFAULT_BRANCH}} || git_with_fallback pull origin main || true
 
 if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
     echo -e "${YELLOW}Branch ${BRANCH} already exists, checking out...${NC}"

--- a/templates/skills/submit-pr.sh.template
+++ b/templates/skills/submit-pr.sh.template
@@ -47,9 +47,20 @@ if [[ -n $(git status --porcelain) ]]; then
     fi
 fi
 
+# Helper function for SSH/HTTPS fallback
+git_with_fallback() {
+    local cmd="$1"
+    shift
+    if ! git "$cmd" "$@" 2>/dev/null; then
+        echo "SSH failed, trying HTTPS via gh auth..."
+        gh auth setup-git 2>/dev/null || true
+        git "$cmd" "$@"
+    fi
+}
+
 # Push branch
 echo "Pushing branch..."
-git push -u origin "$BRANCH" 2>&1 || {
+git_with_fallback push -u origin "$BRANCH" || {
     echo -e "${RED}Error: Failed to push branch${NC}"
     exit 1
 }


### PR DESCRIPTION
## Summary

Addresses feedback from issue #1:
- **Setup script**: Added `scripts/setup-labels.sh` to create required GitHub labels (workflow, phase, and type labels)
- **Settings template**: Added `templates/.claude/settings.local.json.template` for pre-configuring Claude Code permissions
- **SSH/HTTPS fallback**: Updated skill templates to automatically fall back to HTTPS authentication when SSH fails

## Changes

- `scripts/setup-labels.sh` - Creates `agent-ready`, `in-progress`, `needs-review`, `blocked`, phase-0 through phase-6, and type labels
- `templates/.claude/settings.local.json.template` - Pre-configured permissions for workflow skills
- Updated `claim-issue.sh.template` and `submit-pr.sh.template` with `git_with_fallback()` helper function
- Updated `README.md` and `SKILL.md` documentation

## Test plan

- [ ] Run `./scripts/setup-labels.sh` on a test repo
- [ ] Apply toolkit and verify settings.local.json is generated
- [ ] Test skills with both SSH and HTTPS authentication
- [ ] Run `./scripts/validate-templates.sh` to ensure templates are valid

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)