### PR TITLE
Add workflow update check to session

### DIFF
--- a/templates/.claude/toolkit-version.template
+++ b/templates/.claude/toolkit-version.template
@@ -1,0 +1,6 @@
+# Claude Workflow Toolkit Version
+# Auto-generated - do not edit manually
+
+TOOLKIT_SOURCE="{{TOOLKIT_SOURCE}}"
+TOOLKIT_COMMIT="{{TOOLKIT_COMMIT}}"
+TOOLKIT_APPLIED="{{CURRENT_DATE}}"

--- a/templates/skills/check-reviews.sh.template
+++ b/templates/skills/check-reviews.sh.template
@@ -6,6 +6,33 @@
 
 set -euo pipefail
 
+# Toolkit update check (silent unless updates available)
+_check_toolkit_updates() {
+    local toolkit_dir="${HOME}/claude-workflow-toolkit"
+    local version_file=".claude/toolkit-version"
+
+    # Skip if toolkit doesn't exist or version file missing
+    [[ -d "$toolkit_dir/.git" ]] || return 0
+    [[ -f "$version_file" ]] || return 0
+
+    # Get stored commit
+    local stored_commit
+    stored_commit=$(grep "^TOOLKIT_COMMIT=" "$version_file" 2>/dev/null | cut -d'"' -f2)
+    [[ -n "$stored_commit" ]] || return 0
+
+    # Get current toolkit commit (quick local check, no fetch)
+    local current_commit
+    current_commit=$(git -C "$toolkit_dir" rev-parse HEAD 2>/dev/null) || return 0
+
+    # Only notify if different
+    if [[ "$stored_commit" != "$current_commit" ]]; then
+        echo "NOTE: Workflow toolkit updates available in ~/claude-workflow-toolkit"
+        echo "      (Applied: ${stored_commit:0:7}, Current: ${current_commit:0:7})"
+        echo ""
+    fi
+}
+_check_toolkit_updates
+
 echo "Checking for PRs needing review response..."
 echo ""
 


### PR DESCRIPTION
- Add toolkit-version.template to track applied toolkit version
- Add update check to check-reviews skill (runs first in workflow)
- Check is silent unless updates are available (token efficient)
- Uses local git comparison only (no network fetch)
- Document new TOOLKIT_SOURCE and TOOLKIT_COMMIT variables
- Document automatic update check in SKILL.md