### PR TITLE
fix: Correct sync-skills target path to workspace root

### DIFF
--- a/templates/skills/sync-skills.sh.template
+++ b/templates/skills/sync-skills.sh.template
@@ -88,9 +88,10 @@ fi
 
 echo -e "Toolkit: ${BLUE}$TOOLKIT_SOURCE${NC}"
 
-# Determine target
+# Determine target (workspace root, not .claude directory)
 if [[ "$MODE" == "workspace" ]]; then
-    TARGET="${SCRIPT_DIR}/.."
+    # SCRIPT_DIR is .claude/skills, go up two levels to workspace root
+    TARGET="${SCRIPT_DIR}/../.."
 else
     TARGET="$TARGET_PROJECT"
 fi


### PR DESCRIPTION
## Bug Fix

The sync-skills script was targeting `.claude` directory instead of workspace root, causing a nested `.claude/.claude/` structure.

**Root cause:** `SCRIPT_DIR` is `.claude/skills`, so `${SCRIPT_DIR}/..` only goes to `.claude`, not the workspace root.

**Fix:** Changed to `${SCRIPT_DIR}/../..` to go up TWO levels to reach workspace root.

This commit was created after PR #30 was merged but before it was pushed, so it was missed in the merge.