### PR TITLE
fix: Add tilde expansion for TOOLKIT_SOURCE paths

### DIFF
--- a/templates/skills/check-reviews.sh.template
+++ b/templates/skills/check-reviews.sh.template
@@ -135,6 +135,8 @@ _get_repo_info
 # Toolkit update check (silent unless updates available)
 _check_toolkit_updates() {
     local toolkit_dir="${TOOLKIT_SOURCE:-${HOME}/claude-workflow-toolkit}"
+    # Expand tilde if present (tilde doesn't expand when read from config file)
+    toolkit_dir="${toolkit_dir/#\~/$HOME}"
     local version_file
 
     # Locate version file based on mode

--- a/templates/skills/check-workflow.sh.template
+++ b/templates/skills/check-workflow.sh.template
@@ -144,6 +144,8 @@ if [[ -z "$ISSUE" ]]; then
 
     # Find toolkit source for validation
     TOOLKIT_SOURCE="${TOOLKIT_SOURCE:-}"
+    # Expand tilde if present (tilde doesn't expand when read from config file)
+    TOOLKIT_SOURCE="${TOOLKIT_SOURCE/#\~/$HOME}"
     if [[ -z "$TOOLKIT_SOURCE" ]]; then
         if [[ -d "$HOME/claude-workflow-toolkit" ]]; then
             TOOLKIT_SOURCE="$HOME/claude-workflow-toolkit"

--- a/templates/skills/sync-skills.sh.template
+++ b/templates/skills/sync-skills.sh.template
@@ -71,6 +71,9 @@ echo "========================================"
 # Find toolkit source
 TOOLKIT_SOURCE="${TOOLKIT_SOURCE:-}"
 
+# Expand tilde if present (tilde doesn't expand when read from config file)
+TOOLKIT_SOURCE="${TOOLKIT_SOURCE/#\~/$HOME}"
+
 if [[ -z "$TOOLKIT_SOURCE" ]]; then
     # Try common locations
     if [[ -d "$HOME/claude-workflow-toolkit" ]]; then


### PR DESCRIPTION
## Summary

- Fixes tilde (`~`) not expanding when `TOOLKIT_SOURCE` is read from workspace-config
- Added explicit tilde expansion to sync-skills, check-workflow, and check-reviews templates
- Tested by setting `TOOLKIT_SOURCE="~/claude-workflow-toolkit"` in workspace-config

## Test plan

- [x] Set `TOOLKIT_SOURCE="~/claude-workflow-toolkit"` in workspace-config
- [x] Ran `/sync-skills` - successfully found toolkit and synced skills
- [x] Verified the path was expanded correctly in output

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)