### PR TITLE
feat: Consolidate workflow entry points into /worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,42 +66,54 @@ Or manually:
 
 ## Agent Priming
 
-To ensure agents follow the PR-based workflow correctly, start them with context:
+To ensure agents follow the PR-based workflow correctly, start them with the unified `/worker` command:
 
 ### Recommended Startup Command
 
 ```bash
 cd ~/workspaces/myproject
-claude -c "read CLAUDE.md then /check-workflow"
+claude -c "read CLAUDE.md then /worker --status"
 ```
 
 This ensures the agent:
 1. **Reads workflow rules** - Including "NEVER push to main"
-2. **Sees workspace status** - Outdated skills, pending reviews, available issues
-3. **Knows entry points** - `/check-reviews`, `/claim-issue`, `/sync-skills`
+2. **Sees comprehensive status** - Skills, reviews, issues, branch context
+3. **Gets context-aware guidance** - Suggested next steps based on current state
 
-### Alternative: Autonomous Worker
+### Single Work Cycle
 
-For fully autonomous operation:
+For one complete work cycle (claim → implement → submit):
 
 ```bash
 claude -c "/worker --once"
 ```
 
 The worker will:
-1. Check for PRs needing attention
+1. Check for PRs needing attention (blocks if found)
 2. Find and claim an `agent-ready` issue
-3. Wait for you to implement
-4. Run quality gates and submit PR
+3. Pause for implementation
+4. Run quality gates and submit PR when code is ready
 
-### Why Priming Matters
+### Fully Autonomous
 
-Without priming, agents may:
-- Push directly to main (bypassing PR review)
-- Miss the workflow skills entirely
-- Not know about the review-first policy
+For continuous autonomous operation:
 
-The `CLAUDE.md` file and `/check-workflow` command together provide complete context.
+```bash
+claude -c "/worker"
+```
+
+### Why `/worker` as Entry Point
+
+The `/worker` command is the **unified entry point** for all workflow operations:
+
+| Mode | Purpose |
+|------|---------|
+| `/worker --status` | What needs attention? (start here) |
+| `/worker --once` | One complete work cycle |
+| `/worker` | Continuous autonomous loop |
+| `/worker --help` | Show all options |
+
+This consolidation means agents always know where to start and what to do next.
 
 ## Installation Modes
 

--- a/templates/.claude/commands/worker.md.template
+++ b/templates/.claude/commands/worker.md.template
@@ -1,40 +1,119 @@
 ---
 name: worker
-description: Autonomous development loop - claim issues, implement, test, submit PRs
-version: 1.0.0
+description: Unified workflow entry point - status, single cycle, or autonomous loop
+version: 2.0.0
 ---
 
 # /worker
 
-Autonomous development loop that claims issues, implements solutions, passes quality gates, and submits PRs.
+**The unified entry point for all workflow operations.** Shows status, runs single cycles, or autonomous loops.
 
-## Usage
+## Quick Start
 
 ```bash
-/worker [options]
+/worker --status    # What needs attention?
+/worker --once      # Start or continue one work cycle
+/worker             # Continuous autonomous mode
+/worker --help      # Show all options
 ```
+
+## Modes
+
+### Status Mode (Recommended Starting Point)
+
+```bash
+/worker --status
+```
+
+Shows comprehensive workflow status:
+- **Skills:** Up to date or needs sync
+- **Reviews:** PRs needing attention
+- **Issues:** Available work count
+- **Branch:** Current context and suggested next steps
+
+### Single Cycle Mode
+
+```bash
+/worker --once
+```
+
+Runs exactly one iteration:
+1. Checks for pending reviews (blocks if found)
+2. Claims next issue OR resumes in-progress work
+3. Pauses for implementation
+4. Runs quality gates when code is ready
+5. Submits PR on success
+
+### Continuous Mode
+
+```bash
+/worker
+```
+
+Autonomous loop processing up to {{WORKER_MAX_ISSUES}} issues.
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
+| `--status`, `-s` | Show workflow status without action |
+| `--once` | Process exactly one issue then exit |
+| `--help`, `-h` | Show usage and all options |
+| `--max-issues <n>` | Maximum issues to process (default: {{WORKER_MAX_ISSUES}}) |
+| `--dry-run` | Preview without making changes |
+| `--reset` | Clear worker state (lock, current issue, queue) |
 | `--project <path>` | Target project directory |
 | `--repo <owner/name>` | Target GitHub repository |
-| `--max-issues <n>` | Maximum issues to process (default: {{WORKER_MAX_ISSUES}}) |
-| `--once` | Process exactly one issue then exit |
-| `--dry-run` | Show what would happen without making changes |
 
-## What It Does
+## Typical Workflow
 
-1. **Checks for pending reviews** - Pauses if PRs have requested changes
-2. **Resumes in-progress work** - Continues any previously claimed issue
-3. **Finds next issue** - Queries for `agent-ready` labeled issues, prioritized by phase
-4. **Claims atomically** - Uses `/claim-issue` to prevent conflicts
-5. **Pauses for implementation** - You implement the solution
-6. **Runs quality gates** - Tests, lint, and security checks
-7. **Retries on failure** - Up to {{WORKER_MAX_RETRIES}} attempts to fix issues
-8. **Submits PR** - Uses `/submit-pr` when gates pass
-9. **Repeats** - Continues until max issues reached or no work available
+```bash
+# 1. Check status
+$ /worker --status
+
+========================================
+Workflow Status
+========================================
+
+Repository: owner/repo
+Branch:     main
+
+----------------------------------------
+Pre-flight Checks
+----------------------------------------
+
+✓ Skills:  Up to date
+✓ Reviews: None pending
+ℹ Issues:  3 ready for work
+
+----------------------------------------
+Next Steps
+----------------------------------------
+
+Ready to start work:
+  /worker --once       Claim next issue and start
+  /claim-issue <n>     Claim specific issue
+
+# 2. Start work cycle
+$ /worker --once
+
+Step 3: Finding next issue...
+Found: #42 - Add user authentication
+Issue #42 claimed. Implement the solution, then run /worker again.
+
+# 3. Implement the feature...
+
+# 4. Continue after implementation
+$ /worker --once
+
+Step 5: Running quality gates...
+Tests:    PASS
+Lint:     PASS
+Security: PASS
+
+Step 6: Submitting PR...
+Issue #42 completed successfully
+```
 
 ## Quality Gates
 
@@ -46,127 +125,69 @@ Before submitting, the worker verifies:
 | Lint | `{{LINT_COMMAND}}` | Must pass |
 | Security | Built-in checks | Warnings logged |
 
-## Decision Queue
-
-When the worker encounters situations requiring human judgment:
-
-1. Creates entry in `.claude/worker/decision-queue/`
-2. Logs the issue and continues with next available work
-3. Human reviews queue and resolves decisions
-
-View pending decisions:
-```bash
-ls .claude/worker/decision-queue/
-cat .claude/worker/decision-queue/*.json
-```
-
 ## State Files
 
-The worker maintains state in `.claude/worker/`:
+Worker state is maintained in `.claude/worker/`:
 
 | File | Purpose |
 |------|---------|
-| `worker.lock` | Prevents multiple workers on same clone |
+| `worker.lock` | Prevents multiple workers |
 | `current-issue` | Issue number being worked |
-| `current-branch` | Branch name for current work |
-| `retry-count` | Quality gate retry attempts |
 | `history.log` | Completed work log |
-| `decision-queue/` | Pending human decisions |
+| `decision-queue/` | Issues needing human input |
 
 ## Examples
 
 ```bash
-# Run worker loop (default: up to {{WORKER_MAX_ISSUES}} issues)
-/worker
+# Check what needs attention
+/worker --status
 
-# Process exactly one issue
+# Start one work cycle
 /worker --once
 
-# Preview what would happen
-/worker --dry-run
+# Preview without changes
+/worker --once --dry-run
 
-# From workspace, target specific project
-/worker --project ~/myproject
+# Target specific project (from workspace)
+/worker --project ~/myproject --status
 
-# With explicit repository
-/worker --repo owner/repo
+# Clear stale state
+/worker --reset
+
+# Full autonomous mode
+/worker --max-issues 5
 ```
-
-## Typical Session
-
-```bash
-$ /worker --once
-
-========================================
-Worker Agent Started
-========================================
-Repository:  owner/repo
-Max issues:  1
-Max retries: 3
-
-Step 1: Checking for pending reviews...
-No pending reviews requiring changes
-
-Step 3: Finding next issue...
-Found: #42 - Add user authentication
-
-Step 4: Claiming issue...
-Issue #42 claimed. Implement the solution, then run /worker again.
-
-# ... implement the feature ...
-
-$ /worker
-
-Step 2: Resuming in-progress issue #42...
-Found commits ready for quality gates
-
-Step 5: Running quality gates...
-Tests:    PASS
-Lint:     PASS
-Security: PASS
-
-All quality gates passed
-
-Step 6: Submitting PR...
-
-Issue #42 completed successfully
-```
-
-## Requirements
-
-- `gh` - GitHub CLI, authenticated
-- `jq` - JSON processor
-- `git` - Version control
 
 ## Related Skills
 
 | Skill | Relationship |
 |-------|--------------|
-| `/claim-issue` | Called internally for atomic claiming |
-| `/submit-pr` | Called internally for PR creation |
-| `/check-reviews` | Checks review status before claiming |
-| `/address-review` | Address feedback when worker pauses |
+| `/check-reviews` | Detailed review view (worker shows summary) |
+| `/claim-issue` | Manual claiming (worker does this automatically) |
+| `/submit-pr` | Manual submission (worker does this automatically) |
+| `/sync-skills` | Update skills (worker checks staleness) |
 
 ## Troubleshooting
 
 ### "Another worker is running"
 
-A previous worker may have crashed. Remove the lock file:
+A previous worker may have crashed:
 ```bash
-rm .claude/worker/worker.lock
+/worker --reset
 ```
 
-### Worker keeps pausing for reviews
+### Worker pauses for reviews
 
-Address the pending reviews first:
+Address pending reviews first:
 ```bash
 /check-reviews
 /address-review <pr-number>
 ```
 
-### Quality gates keep failing
+### Stuck on closed issue branch
 
-Check the specific errors and fix manually, or view the decision queue:
+The status mode will suggest next steps:
 ```bash
-cat .claude/worker/decision-queue/*.json
+/worker --status
+# Shows: git checkout main && git pull
 ```

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -7,45 +7,49 @@ This workspace uses **claude-workflow-toolkit** for structured development.
 **NEVER push directly to main.** Always use the PR-based workflow:
 
 ```
-/check-reviews  →  /claim-issue <number>  →  implement  →  /submit-pr
+/worker --status  →  /worker --once  →  implement  →  /worker --once
 ```
 
 ## Getting Started
 
-1. **Check for pending work first:**
+1. **Check workflow status:**
    ```
-   /check-reviews
+   /worker --status
    ```
+   This shows: skill updates needed, PRs needing attention, available issues, and suggested next steps.
 
-2. **Find and claim an issue:**
+2. **Start a work cycle:**
    ```
-   gh issue list --repo {{REPO_OWNER}}/{{REPO_NAME}} --label agent-ready
-   /claim-issue <number>
+   /worker --once
    ```
+   Claims the next issue and creates a feature branch.
 
-3. **Validate your workflow state:**
+3. **Continue after implementing:**
    ```
-   /check-workflow
+   /worker --once
    ```
+   Runs quality gates and submits PR.
 
 ## Available Skills
 
 | Skill | Purpose |
 |-------|---------|
-| `/check-reviews` | Check for PRs needing attention (run FIRST) |
-| `/claim-issue <n>` | Claim issue and create feature branch |
-| `/check-workflow` | Validate current workflow state |
-| `/submit-pr` | Create PR when implementation complete |
-| `/worker` | Autonomous loop (claim → implement → submit) |
+| `/worker --status` | **Entry point** - Show workflow status and next steps |
+| `/worker --once` | Run one work cycle (claim → implement → submit) |
+| `/worker` | Continuous autonomous loop |
+| `/worker --help` | Show all worker options |
+| `/check-reviews` | Detailed view of PRs needing attention |
+| `/claim-issue <n>` | Claim specific issue (alternative to worker) |
+| `/submit-pr` | Manual PR submission (alternative to worker) |
 | `/sync-skills` | Update skills from toolkit templates |
 
 ## Workflow Rules
 
-1. **Always start with `/check-reviews`** - Address feedback before new work
-2. **One issue at a time** - Claim, implement, submit, then move on
-3. **Use feature branches** - Branch naming: `<issue-number>-<slug>`
-4. **Quality gates must pass** - Tests and lint before PR submission
-5. **Document friction** - Create issues for workflow problems encountered
+1. **Start with `/worker --status`** - See what needs attention
+2. **Address reviews first** - Worker blocks if PRs need attention
+3. **One issue at a time** - Claim, implement, submit, then move on
+4. **Use feature branches** - Branch naming: `<issue-number>-<slug>`
+5. **Quality gates must pass** - Tests and lint before PR submission
 
 ## Quick Reference
 

--- a/templates/skills/check-workflow.sh.template
+++ b/templates/skills/check-workflow.sh.template
@@ -2,8 +2,15 @@
 # Skill: /check-workflow
 # Description: Validate workflow state using optimized GraphQL queries
 # Usage: /check-workflow [--project <path>]
+#
+# NOTE: This skill is being consolidated into /worker --status
+#       Consider using /worker --status for comprehensive workflow status
 
 set -euo pipefail
+
+# Deprecation notice (soft - still functional)
+echo -e "\033[0;33mTip:\033[0m Use /worker --status for comprehensive workflow status"
+echo ""
 
 # ============================================================================
 # WORKSPACE/PROJECT MODE DETECTION
@@ -272,6 +279,12 @@ WARNINGS=0
 # Check issue state
 if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
     echo -e "${RED}CRITICAL:${NC} Issue is closed but you're on its branch"
+    echo ""
+    echo "Suggested next steps:"
+    echo -e "  ${BLUE}git checkout {{DEFAULT_BRANCH}} && git pull${NC}"
+    echo -e "  ${BLUE}/worker --status${NC}"
+    echo -e "  ${BLUE}/claim-issue <next-issue>${NC}"
+    echo ""
     ((ERRORS++))
 fi
 

--- a/templates/skills/worker.sh.template
+++ b/templates/skills/worker.sh.template
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Skill: /worker
-# Description: Autonomous development loop - claim issues, implement, test, submit PRs
-# Usage: /worker [--project <path>] [--max-issues <n>] [--once] [--dry-run]
+# Description: Unified workflow entry point - status, single cycle, or autonomous loop
+# Usage: /worker [--status] [--once] [--help] [--project <path>] [--max-issues <n>]
 
 set -euo pipefail
 
@@ -128,6 +128,8 @@ DRY_RUN=false
 
 # Parse worker-specific flags
 RESET_STATE=false
+SHOW_STATUS=false
+SHOW_HELP=false
 
 _parse_worker_flags() {
     local args=()
@@ -147,6 +149,14 @@ _parse_worker_flags() {
                 ;;
             --reset)
                 RESET_STATE=true
+                shift
+                ;;
+            --status|-s)
+                SHOW_STATUS=true
+                shift
+                ;;
+            --help|-h)
+                SHOW_HELP=true
                 shift
                 ;;
             *)
@@ -441,6 +451,272 @@ _has_commits_ahead() {
 }
 
 # ============================================================================
+# HELP AND STATUS
+# ============================================================================
+
+_show_help() {
+    cat <<EOF
+Usage: /worker [OPTIONS]
+
+Unified workflow entry point for development.
+
+MODES:
+  /worker --status      Show workflow status (skills, reviews, issues)
+  /worker --once        Run one complete cycle (claim → implement → submit)
+  /worker               Continuous autonomous loop
+  /worker --help        Show this help message
+
+OPTIONS:
+  --status, -s          Show workflow status without taking action
+  --once                Process exactly one issue then stop
+  --max-issues <n>      Maximum issues to process (default: {{WORKER_MAX_ISSUES}})
+  --dry-run             Show what would happen without making changes
+  --reset               Clear worker state (lock, current issue, queue)
+  --project, -p <path>  Target project path (overrides workspace config)
+  --repo, -r <o/n>      GitHub repo as owner/name (overrides auto-detection)
+  --help, -h            Show this help message
+
+WORKFLOW:
+  1. /worker --status   Check what needs attention
+  2. /worker --once     Start one work cycle
+  3. Implement solution
+  4. /worker --once     Continue (runs quality gates, submits PR)
+  5. Repeat
+
+EXAMPLES:
+  /worker --status                    # See current state
+  /worker --once                      # Claim and start one issue
+  /worker --once --dry-run            # Preview without changes
+  /worker --max-issues 3              # Process up to 3 issues
+  /worker --reset                     # Clear stale state
+
+STATE FILES:
+  Worker state is stored in: ${SCRIPT_DIR}/../worker/
+  - current-issue: Currently claimed issue
+  - history.log: Completed issue history
+  - decision-queue/: Issues needing human input
+
+EOF
+}
+
+_check_skill_staleness() {
+    # Returns: 0=up-to-date, 1=outdated, 2=cannot-check
+    # Sets: SKILLS_OUTDATED, SKILLS_MISSING
+    SKILLS_OUTDATED=0
+    SKILLS_MISSING=0
+
+    # Find toolkit source
+    local toolkit_source="${TOOLKIT_SOURCE:-}"
+    # Expand tilde if present (tilde doesn't expand when read from config file)
+    toolkit_source="${toolkit_source/#\~/$HOME}"
+
+    if [[ -z "$toolkit_source" ]]; then
+        if [[ -d "$HOME/claude-workflow-toolkit" ]]; then
+            toolkit_source="$HOME/claude-workflow-toolkit"
+        elif [[ -d "${SCRIPT_DIR}/../../templates" ]]; then
+            toolkit_source="$(realpath "${SCRIPT_DIR}/../..")"
+        fi
+    fi
+
+    if [[ -z "$toolkit_source" ]] || [[ ! -d "$toolkit_source/templates/skills" ]]; then
+        return 2  # Cannot check
+    fi
+
+    local skills_dir="${SCRIPT_DIR}"
+    for template in "$toolkit_source/templates/skills/"*.sh.template; do
+        [[ -f "$template" ]] || continue
+        local skill_name
+        skill_name=$(basename "$template" .sh.template)
+        local installed_file="$skills_dir/$skill_name"
+
+        if [[ ! -f "$installed_file" ]]; then
+            ((++SKILLS_MISSING))
+        elif [[ "$template" -nt "$installed_file" ]]; then
+            ((++SKILLS_OUTDATED))
+        fi
+    done
+
+    if [[ $SKILLS_OUTDATED -eq 0 ]] && [[ $SKILLS_MISSING -eq 0 ]]; then
+        return 0  # Up to date
+    fi
+    return 1  # Outdated
+}
+
+_get_branch_context() {
+    # Returns context about current branch state
+    # Sets: BRANCH_NAME, BRANCH_ISSUE, BRANCH_CONTEXT
+    BRANCH_NAME=$(_git branch --show-current 2>/dev/null || echo "")
+    BRANCH_ISSUE=""
+    BRANCH_CONTEXT="unknown"
+
+    if [[ -z "$BRANCH_NAME" ]]; then
+        BRANCH_CONTEXT="detached"
+        return
+    fi
+
+    if [[ "$BRANCH_NAME" == "{{DEFAULT_BRANCH}}" ]] || [[ "$BRANCH_NAME" == "main" ]] || [[ "$BRANCH_NAME" == "master" ]]; then
+        BRANCH_CONTEXT="default"
+        return
+    fi
+
+    # Extract issue number from branch name
+    BRANCH_ISSUE=$(echo "$BRANCH_NAME" | grep -oE '^[0-9]+' || echo "")
+
+    if [[ -z "$BRANCH_ISSUE" ]]; then
+        BRANCH_CONTEXT="feature"  # Feature branch without issue number
+        return
+    fi
+
+    # Check issue state
+    local issue_state
+    issue_state=$(gh issue view "$BRANCH_ISSUE" --repo "$OWNER/$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+
+    case "$issue_state" in
+        OPEN)
+            BRANCH_CONTEXT="active"
+            ;;
+        CLOSED)
+            BRANCH_CONTEXT="closed"
+            ;;
+        *)
+            BRANCH_CONTEXT="unknown"
+            ;;
+    esac
+}
+
+_show_status() {
+    echo ""
+    echo "========================================"
+    echo -e "${BLUE}Workflow Status${NC}"
+    echo "========================================"
+    echo ""
+    echo -e "Repository: ${BLUE}$OWNER/$REPO${NC}"
+
+    # Branch context
+    _get_branch_context
+    echo -e "Branch:     ${BLUE}$BRANCH_NAME${NC}"
+    echo ""
+
+    # Skills staleness
+    echo "----------------------------------------"
+    echo "Pre-flight Checks"
+    echo "----------------------------------------"
+    echo ""
+
+    _check_skill_staleness
+    local staleness_result=$?
+    case $staleness_result in
+        0)
+            echo -e "${GREEN}✓ Skills:${NC} Up to date"
+            ;;
+        1)
+            echo -e "${YELLOW}! Skills:${NC} $SKILLS_OUTDATED outdated, $SKILLS_MISSING missing"
+            echo -e "  Run: ${BLUE}/sync-skills${NC}"
+            ;;
+        2)
+            echo -e "${YELLOW}? Skills:${NC} Could not locate toolkit for validation"
+            ;;
+    esac
+
+    # Pending reviews
+    local pending_reviews
+    pending_reviews=$(gh pr list --repo "$OWNER/$REPO" --state open --json number,reviews \
+        --jq '[.[] | select(.reviews | length > 0) | select(.reviews | map(select(.state == "CHANGES_REQUESTED")) | length > 0)] | length' 2>/dev/null || echo "0")
+
+    if [[ "$pending_reviews" -gt 0 ]]; then
+        echo -e "${YELLOW}! Reviews:${NC} $pending_reviews PR(s) need attention"
+        echo -e "  Run: ${BLUE}/check-reviews${NC}"
+    else
+        echo -e "${GREEN}✓ Reviews:${NC} None pending"
+    fi
+
+    # Available issues
+    local agent_ready
+    agent_ready=$(gh issue list --repo "$OWNER/$REPO" --label "agent-ready" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+    echo -e "${BLUE}ℹ Issues:${NC}  $agent_ready ready for work"
+
+    # Current worker state
+    local current_issue
+    current_issue=$(_get_current_issue 2>/dev/null || echo "")
+    if [[ -n "$current_issue" ]]; then
+        echo -e "${BLUE}ℹ Worker:${NC}  Issue #$current_issue in progress"
+    fi
+
+    # Pending decisions
+    local decision_count
+    decision_count=$(find "$DECISION_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$decision_count" -gt 0 ]]; then
+        echo -e "${YELLOW}! Queue:${NC}   $decision_count decision(s) pending"
+        echo -e "  Review: ${BLUE}ls $DECISION_DIR${NC}"
+    fi
+
+    echo ""
+    echo "----------------------------------------"
+    echo "Next Steps"
+    echo "----------------------------------------"
+    echo ""
+
+    # Context-aware next steps (addresses #34)
+    case "$BRANCH_CONTEXT" in
+        closed)
+            echo -e "${YELLOW}You're on a branch for closed issue #$BRANCH_ISSUE${NC}"
+            echo ""
+            echo "Suggested actions:"
+            echo -e "  ${BLUE}git checkout {{DEFAULT_BRANCH}} && git pull${NC}"
+            echo -e "  ${BLUE}/worker --status${NC}"
+            ;;
+        active)
+            echo -e "Working on issue #$BRANCH_ISSUE"
+            echo ""
+            if [[ -n "$current_issue" ]] && [[ "$current_issue" == "$BRANCH_ISSUE" ]]; then
+                if _has_commits_ahead 2>/dev/null; then
+                    echo "Ready for quality gates and PR submission:"
+                    echo -e "  ${BLUE}/worker --once${NC}    Run quality gates and submit PR"
+                elif _has_uncommitted_changes 2>/dev/null; then
+                    echo "Uncommitted changes detected:"
+                    echo -e "  ${BLUE}git add . && git commit${NC}"
+                    echo -e "  ${BLUE}/worker --once${NC}"
+                else
+                    echo "Implement the solution, then:"
+                    echo -e "  ${BLUE}/worker --once${NC}    Continue workflow"
+                fi
+            else
+                echo "Continue working or submit:"
+                echo -e "  ${BLUE}/worker --once${NC}    Run quality gates and submit PR"
+            fi
+            ;;
+        default)
+            if [[ "$pending_reviews" -gt 0 ]]; then
+                echo "Address reviews first:"
+                echo -e "  ${BLUE}/check-reviews${NC}       See review details"
+                echo -e "  ${BLUE}/address-review <n>${NC}  Checkout PR and see feedback"
+            elif [[ "$agent_ready" -gt 0 ]]; then
+                echo "Ready to start work:"
+                echo -e "  ${BLUE}/worker --once${NC}       Claim next issue and start"
+                echo -e "  ${BLUE}/claim-issue <n>${NC}     Claim specific issue"
+                echo ""
+                echo "Find work:"
+                echo -e "  ${BLUE}gh issue list --repo $OWNER/$REPO --label agent-ready${NC}"
+            else
+                echo "No issues ready for work."
+                echo ""
+                echo "Check for new issues or create one:"
+                echo -e "  ${BLUE}gh issue list --repo $OWNER/$REPO${NC}"
+            fi
+            ;;
+        *)
+            echo "Available commands:"
+            echo -e "  ${BLUE}/worker --once${NC}       Start or continue one work cycle"
+            echo -e "  ${BLUE}/worker${NC}              Run autonomous loop"
+            echo -e "  ${BLUE}/check-reviews${NC}       Check for PR feedback"
+            echo -e "  ${BLUE}/claim-issue <n>${NC}     Claim specific issue"
+            ;;
+    esac
+
+    echo ""
+}
+
+# ============================================================================
 # MAIN WORKER LOOP
 # ============================================================================
 
@@ -642,20 +918,34 @@ REMAINING_ARGS=()
 _parse_worker_flags "$@"
 set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
 
+# Handle --help flag early (before mode detection)
+if $SHOW_HELP; then
+    _show_help
+    exit 0
+fi
+
 # Initialize
 _detect_mode
 _get_repo_info
 
+# Set up worker paths (needed for status and reset)
+WORKER_DIR="${SCRIPT_DIR}/../worker"
+LOCK_FILE="${WORKER_DIR}/worker.lock"
+STATE_FILE="${WORKER_DIR}/current-issue"
+BRANCH_FILE="${WORKER_DIR}/current-branch"
+RETRY_FILE="${WORKER_DIR}/retry-count"
+DECISION_DIR="${WORKER_DIR}/decision-queue"
+mkdir -p "$WORKER_DIR" "$DECISION_DIR"
+
 # Handle --reset flag
 if $RESET_STATE; then
-    # Set up paths without acquiring lock
-    WORKER_DIR="${SCRIPT_DIR}/../worker"
-    LOCK_FILE="${WORKER_DIR}/worker.lock"
-    STATE_FILE="${WORKER_DIR}/current-issue"
-    BRANCH_FILE="${WORKER_DIR}/current-branch"
-    RETRY_FILE="${WORKER_DIR}/retry-count"
-    DECISION_DIR="${WORKER_DIR}/decision-queue"
     _reset_worker_state
+    exit 0
+fi
+
+# Handle --status flag
+if $SHOW_STATUS; then
+    _show_status
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Makes `/worker` the unified entry point for all workflow operations:

- **`/worker --status`** - Comprehensive status with context-aware next steps
- **`/worker --help`** - Usage documentation  
- **`/worker --once`** - Single work cycle (existing)
- **`/worker`** - Continuous loop (existing)

### Status Mode Features

- Skill staleness detection (automatically finds outdated skills)
- Pending reviews check
- Available issues count
- Branch context awareness (main, active issue, closed issue)
- Context-aware "Next Steps" guidance

### Migration Path

- `/check-workflow` shows soft deprecation notice: "Tip: Use /worker --status"
- `/check-workflow` now shows next steps when on closed issue branch (Fixes #34)
- All functionality preserved, just consolidated

### Documentation Updates

- `CLAUDE.md`: `/worker --status` as primary entry point
- `README.md`: Revised "Agent Priming" section
- `worker.md`: Comprehensive documentation of all modes

## Test plan

- [x] `/worker --help` shows usage and options
- [x] `/worker --status` shows comprehensive status
- [x] Status correctly detects branch context (active issue)
- [x] `/check-workflow` shows deprecation tip
- [x] Skills install correctly with new templates

Fixes #34, Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)