### PR TITLE
feat: Add telemetry-aggregate skill for log aggregation

### DIFF
--- a/templates/.claude/commands/telemetry-aggregate.md.template
+++ b/templates/.claude/commands/telemetry-aggregate.md.template
@@ -1,0 +1,210 @@
+---
+name: telemetry-aggregate
+description: Aggregate raw invocation logs into JSON tally format
+version: 1.0.0
+---
+
+# /telemetry-aggregate
+
+Aggregate raw invocation logs into the persistent JSON tally format (usage.json).
+
+## Usage
+
+```bash
+/telemetry-aggregate              # Incremental update
+/telemetry-aggregate --full       # Full rebuild from all logs
+/telemetry-aggregate --dry-run    # Preview without writing
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--full`, `-f` | Rebuild from all logs (ignore cursor) |
+| `--dry-run`, `-n` | Preview changes without writing |
+| `--verbose`, `-v` | Show processing details |
+| `--project <path>` | Target project path |
+
+## What It Does
+
+1. **Reads** raw invocation logs from `.claude/telemetry/invocations.log`
+2. **Aggregates** into per-skill statistics and session metrics
+3. **Writes** structured JSON to `.claude/telemetry/usage.json`
+4. **Tracks** cursor position for incremental updates
+
+## Modes
+
+### Incremental (default)
+
+Only processes log entries since the last aggregation:
+
+```bash
+/telemetry-aggregate
+```
+
+- Reads `log_cursor` from existing usage.json
+- Processes only new entries
+- Merges with existing aggregations
+- Updates cursor to latest timestamp
+
+### Full Rebuild
+
+Reprocesses all log entries from scratch:
+
+```bash
+/telemetry-aggregate --full
+```
+
+Use when:
+- usage.json is corrupted
+- Schema has changed
+- You want fresh aggregation
+
+## Output Format
+
+The skill produces `usage.json` with:
+
+```json
+{
+  "version": "1.0",
+  "skills": {
+    "check-reviews": {
+      "invocations": 47,
+      "successes": 47,
+      "failures": 0,
+      "total_duration_ms": 66580,
+      "avg_duration_ms": 1416,
+      "last_invoked": "2026-02-03T14:23:45Z",
+      "first_invoked": "2026-01-15T09:12:00Z",
+      "sessions": 23
+    }
+  },
+  "sessions": {
+    "total": 47,
+    "skill_invocations": 132,
+    "avg_skills_per_session": 2.8
+  },
+  "periods": {
+    "last_7d": { "invocations": 45, "sessions": 12 },
+    "last_30d": { "invocations": 132, "sessions": 47 }
+  },
+  "updated": "2026-02-03T14:45:00Z",
+  "log_cursor": "2026-02-03T14:45:00Z"
+}
+```
+
+## Workflow
+
+### Regular Usage
+
+Run periodically to keep usage.json updated:
+
+```bash
+# After a work session
+/telemetry-aggregate
+
+# View the report
+/telemetry-report
+```
+
+### After Log Rotation
+
+If you rotate/archive logs, rebuild aggregation:
+
+```bash
+/telemetry-aggregate --full
+```
+
+### Debugging
+
+Preview what would be aggregated:
+
+```bash
+/telemetry-aggregate --dry-run --verbose
+```
+
+## Examples
+
+### Initial Aggregation
+
+First run creates usage.json:
+
+```bash
+$ /telemetry-aggregate
+
+========================================
+Telemetry Aggregation
+========================================
+
+Mode: Initial aggregation
+
+Entries to process: 142
+
+========================================
+Summary
+========================================
+
+Skills tracked:      8
+Total invocations:  142
+Total sessions:     47
+New cursor:         2026-02-03T14:45:00Z
+
+Aggregation complete
+Output: .claude/telemetry/usage.json
+```
+
+### Incremental Update
+
+Subsequent runs are fast:
+
+```bash
+$ /telemetry-aggregate
+
+========================================
+Telemetry Aggregation
+========================================
+
+Mode: Incremental (from cursor)
+Cursor: 2026-02-03T14:45:00Z
+
+Entries to process: 5
+
+========================================
+Summary
+========================================
+
+Skills tracked:      8
+Total invocations:  147
+Total sessions:     48
+New cursor:         2026-02-03T15:30:00Z
+
+Aggregation complete
+```
+
+### Already Up to Date
+
+```bash
+$ /telemetry-aggregate
+
+========================================
+Telemetry Aggregation
+========================================
+
+Mode: Incremental (from cursor)
+Cursor: 2026-02-03T15:30:00Z
+
+Already up to date
+No new entries to process.
+```
+
+## Requirements
+
+- `jq` - JSON processor
+- Telemetry logging enabled (invocations.log exists)
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|--------------|
+| `/telemetry-report` | Read and display aggregated data |
+| `lib/telemetry.sh` | Generate invocation logs |

--- a/templates/skills/telemetry-aggregate.sh.template
+++ b/templates/skills/telemetry-aggregate.sh.template
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# Skill: /telemetry-aggregate
+# Description: Aggregate raw invocation logs into JSON tally format
+# Usage: /telemetry-aggregate [--full] [--dry-run] [--verbose]
+
+set -euo pipefail
+
+# ============================================================================
+# WORKSPACE/PROJECT MODE DETECTION
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_PROJECT=""
+MODE=""
+REMAINING_ARGS=()
+
+_parse_project_flag() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --project|-p)
+                if [[ -n "${2:-}" ]]; then
+                    TARGET_PROJECT="$2"
+                    shift 2
+                else
+                    echo "Error: --project requires a path argument"
+                    exit 1
+                fi
+                ;;
+            *)
+                REMAINING_ARGS+=("$1")
+                shift
+                ;;
+        esac
+    done
+}
+
+_load_workspace_config() {
+    local config_file="${SCRIPT_DIR}/../workspace-config"
+    if [[ -f "$config_file" ]]; then
+        # shellcheck source=/dev/null
+        source "$config_file"
+        TARGET_PROJECT="${TARGET_PROJECT_PATH:-}"
+        return 0
+    fi
+    return 1
+}
+
+_detect_mode() {
+    if [[ -n "$TARGET_PROJECT" ]]; then
+        MODE="explicit"
+        return
+    fi
+    if _load_workspace_config; then
+        MODE="workspace"
+        return
+    fi
+    if git rev-parse --git-dir > /dev/null 2>&1; then
+        TARGET_PROJECT="$(pwd)"
+        MODE="in-project"
+        return
+    fi
+    echo "Error: Not in a git repository and no workspace config found."
+    exit 1
+}
+
+_parse_project_flag "$@"
+set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
+_detect_mode
+
+# ============================================================================
+# CONFIGURATION
+# ============================================================================
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Options
+FULL_REBUILD=false
+DRY_RUN=false
+VERBOSE=false
+
+# Paths
+if [[ "$MODE" == "in-project" ]]; then
+    TELEMETRY_DIR=".claude/telemetry"
+else
+    TELEMETRY_DIR="${TARGET_PROJECT}/.claude/telemetry"
+fi
+LOG_FILE="${TELEMETRY_DIR}/invocations.log"
+USAGE_FILE="${TELEMETRY_DIR}/usage.json"
+
+# ============================================================================
+# ARGUMENT PARSING
+# ============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --full|-f)
+            FULL_REBUILD=true
+            shift
+            ;;
+        --dry-run|-n)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --help|-h)
+            cat <<EOF
+Usage: /telemetry-aggregate [OPTIONS]
+
+Aggregate raw invocation logs into JSON tally format (usage.json).
+
+OPTIONS:
+  --full, -f        Full rebuild from all logs (ignore cursor)
+  --dry-run, -n     Preview changes without writing
+  --verbose, -v     Show processing details
+  --project <path>  Target project path
+  --help, -h        Show this help
+
+MODES:
+  Incremental (default):  Process only new log entries since last run
+  Full (--full):          Rebuild usage.json from all logs
+
+FILES:
+  Input:  .claude/telemetry/invocations.log
+  Output: .claude/telemetry/usage.json
+
+EXAMPLES:
+  /telemetry-aggregate              # Incremental update
+  /telemetry-aggregate --full       # Full rebuild
+  /telemetry-aggregate --dry-run    # Preview changes
+
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ============================================================================
+# FUNCTIONS
+# ============================================================================
+
+# Initialize empty usage.json structure
+_init_usage_json() {
+    cat <<'EOF'
+{
+  "version": "1.0",
+  "skills": {},
+  "sessions": {
+    "total": 0,
+    "skill_invocations": 0,
+    "avg_skills_per_session": 0
+  },
+  "periods": {
+    "last_7d": {
+      "invocations": 0,
+      "sessions": 0,
+      "updated": null
+    },
+    "last_30d": {
+      "invocations": 0,
+      "sessions": 0,
+      "updated": null
+    }
+  },
+  "updated": null,
+  "log_cursor": null
+}
+EOF
+}
+
+# Process log entries and output aggregated JSON
+_aggregate_logs() {
+    local cursor="${1:-}"
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Calculate period boundaries
+    local seven_days_ago thirty_days_ago
+    seven_days_ago=$(date -u -d "-7 days" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-7d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+    thirty_days_ago=$(date -u -d "-30 days" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v-30d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+
+    # Use awk to process logs and output JSON
+    awk -F'|' -v cursor="$cursor" -v now="$now" -v seven_days="$seven_days_ago" -v thirty_days="$thirty_days_ago" '
+    BEGIN {
+        total_invocations = 0
+        last_timestamp = ""
+    }
+
+    # Skip malformed lines
+    NF < 5 { next }
+
+    # Skip entries before cursor (unless cursor is empty)
+    cursor != "" && $1 <= cursor { next }
+
+    {
+        timestamp = $1
+        session = $2
+        skill = $3
+        exit_code = $4
+        duration = $5
+
+        # Track last timestamp for cursor
+        if (timestamp > last_timestamp) {
+            last_timestamp = timestamp
+        }
+
+        # Per-skill stats
+        skill_invocations[skill]++
+        skill_duration[skill] += duration
+        if (exit_code == 0) {
+            skill_successes[skill]++
+        } else {
+            skill_failures[skill]++
+        }
+
+        # Track first/last invocation per skill
+        if (skill_first[skill] == "" || timestamp < skill_first[skill]) {
+            skill_first[skill] = timestamp
+        }
+        if (timestamp > skill_last[skill]) {
+            skill_last[skill] = timestamp
+        }
+
+        # Track sessions per skill
+        if (!skill_sessions[skill, session]) {
+            skill_sessions[skill, session] = 1
+            skill_session_count[skill]++
+        }
+
+        # Global session tracking
+        if (!sessions[session]) {
+            sessions[session] = 1
+            session_count++
+        }
+
+        # Period tracking
+        if (seven_days != "" && timestamp >= seven_days) {
+            period_7d_invocations++
+            if (!period_7d_sessions[session]) {
+                period_7d_sessions[session] = 1
+                period_7d_session_count++
+            }
+        }
+        if (thirty_days != "" && timestamp >= thirty_days) {
+            period_30d_invocations++
+            if (!period_30d_sessions[session]) {
+                period_30d_sessions[session] = 1
+                period_30d_session_count++
+            }
+        }
+
+        total_invocations++
+    }
+
+    END {
+        # Output JSON
+        printf "{\n"
+        printf "  \"version\": \"1.0\",\n"
+        printf "  \"skills\": {\n"
+
+        # Output skills
+        first_skill = 1
+        for (skill in skill_invocations) {
+            if (!first_skill) printf ",\n"
+            first_skill = 0
+
+            inv = skill_invocations[skill]
+            succ = skill_successes[skill] + 0
+            fail = skill_failures[skill] + 0
+            dur = skill_duration[skill]
+            avg = (inv > 0) ? int(dur / inv) : 0
+
+            printf "    \"%s\": {\n", skill
+            printf "      \"invocations\": %d,\n", inv
+            printf "      \"successes\": %d,\n", succ
+            printf "      \"failures\": %d,\n", fail
+            printf "      \"total_duration_ms\": %d,\n", dur
+            printf "      \"avg_duration_ms\": %d,\n", avg
+            printf "      \"last_invoked\": \"%s\",\n", skill_last[skill]
+            printf "      \"first_invoked\": \"%s\",\n", skill_first[skill]
+            printf "      \"sessions\": %d\n", skill_session_count[skill]
+            printf "    }"
+        }
+
+        printf "\n  },\n"
+
+        # Sessions
+        avg_per_session = (session_count > 0) ? total_invocations / session_count : 0
+        printf "  \"sessions\": {\n"
+        printf "    \"total\": %d,\n", session_count
+        printf "    \"skill_invocations\": %d,\n", total_invocations
+        printf "    \"avg_skills_per_session\": %.1f\n", avg_per_session
+        printf "  },\n"
+
+        # Periods
+        printf "  \"periods\": {\n"
+        printf "    \"last_7d\": {\n"
+        printf "      \"invocations\": %d,\n", period_7d_invocations + 0
+        printf "      \"sessions\": %d,\n", period_7d_session_count + 0
+        printf "      \"updated\": \"%s\"\n", now
+        printf "    },\n"
+        printf "    \"last_30d\": {\n"
+        printf "      \"invocations\": %d,\n", period_30d_invocations + 0
+        printf "      \"sessions\": %d,\n", period_30d_session_count + 0
+        printf "      \"updated\": \"%s\"\n", now
+        printf "    }\n"
+        printf "  },\n"
+
+        # Metadata
+        printf "  \"updated\": \"%s\",\n", now
+        if (last_timestamp != "") {
+            printf "  \"log_cursor\": \"%s\",\n", last_timestamp
+        } else {
+            printf "  \"log_cursor\": null,\n"
+        }
+        printf "  \"_entries_processed\": %d\n", total_invocations
+        printf "}\n"
+    }
+    ' "$LOG_FILE"
+}
+
+# Merge new aggregation into existing usage.json
+_merge_usage() {
+    local existing="$1"
+    local new_data="$2"
+
+    # Use jq to merge the data
+    jq -s '
+    .[0] as $old | .[1] as $new |
+    {
+        version: "1.0",
+        skills: (
+            ($old.skills // {}) as $old_skills |
+            ($new.skills // {}) as $new_skills |
+            $old_skills * $new_skills |
+            to_entries | map(
+                .key as $k |
+                if $new_skills[$k] then
+                    .value = {
+                        invocations: (($old_skills[$k].invocations // 0) + ($new_skills[$k].invocations // 0)),
+                        successes: (($old_skills[$k].successes // 0) + ($new_skills[$k].successes // 0)),
+                        failures: (($old_skills[$k].failures // 0) + ($new_skills[$k].failures // 0)),
+                        total_duration_ms: (($old_skills[$k].total_duration_ms // 0) + ($new_skills[$k].total_duration_ms // 0)),
+                        avg_duration_ms: (
+                            ((($old_skills[$k].total_duration_ms // 0) + ($new_skills[$k].total_duration_ms // 0)) /
+                             ((($old_skills[$k].invocations // 0) + ($new_skills[$k].invocations // 0)) | if . == 0 then 1 else . end)) | floor
+                        ),
+                        last_invoked: ([($old_skills[$k].last_invoked // ""), ($new_skills[$k].last_invoked // "")] | map(select(. != "")) | max),
+                        first_invoked: ([($old_skills[$k].first_invoked // ""), ($new_skills[$k].first_invoked // "")] | map(select(. != "")) | min),
+                        sessions: (($old_skills[$k].sessions // 0) + ($new_skills[$k].sessions // 0))
+                    }
+                else .
+                end
+            ) | from_entries
+        ),
+        sessions: {
+            total: (($old.sessions.total // 0) + ($new.sessions.total // 0)),
+            skill_invocations: (($old.sessions.skill_invocations // 0) + ($new.sessions.skill_invocations // 0)),
+            avg_skills_per_session: (
+                ((($old.sessions.skill_invocations // 0) + ($new.sessions.skill_invocations // 0)) /
+                 ((($old.sessions.total // 0) + ($new.sessions.total // 0)) | if . == 0 then 1 else . end)) | . * 10 | floor | . / 10
+            )
+        },
+        periods: $new.periods,
+        updated: $new.updated,
+        log_cursor: $new.log_cursor
+    } | del(._entries_processed)
+    ' <(echo "$existing") <(echo "$new_data")
+}
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "${BLUE}Telemetry Aggregation${NC}"
+echo "========================================"
+echo ""
+
+# Check if log file exists
+if [[ ! -f "$LOG_FILE" ]]; then
+    echo -e "${YELLOW}No invocation log found${NC}"
+    echo "Log file: $LOG_FILE"
+    echo ""
+    echo "Telemetry logging not yet enabled."
+    exit 0
+fi
+
+# Check if log file is empty
+if [[ ! -s "$LOG_FILE" ]]; then
+    echo -e "${YELLOW}Invocation log is empty${NC}"
+    exit 0
+fi
+
+# Load or initialize usage.json
+if [[ -f "$USAGE_FILE" ]] && [[ "$FULL_REBUILD" == "false" ]]; then
+    EXISTING_USAGE=$(cat "$USAGE_FILE")
+    CURSOR=$(echo "$EXISTING_USAGE" | jq -r '.log_cursor // ""')
+    echo -e "${CYAN}Mode:${NC} Incremental (from cursor)"
+    if [[ -n "$CURSOR" && "$CURSOR" != "null" ]]; then
+        echo -e "${CYAN}Cursor:${NC} $CURSOR"
+    fi
+else
+    EXISTING_USAGE=$(_init_usage_json)
+    CURSOR=""
+    if [[ "$FULL_REBUILD" == "true" ]]; then
+        echo -e "${CYAN}Mode:${NC} Full rebuild"
+    else
+        echo -e "${CYAN}Mode:${NC} Initial aggregation"
+    fi
+fi
+
+echo ""
+
+# Count entries to process
+if [[ -n "$CURSOR" && "$CURSOR" != "null" ]]; then
+    ENTRIES_TO_PROCESS=$(awk -F'|' -v cursor="$CURSOR" '$1 > cursor' "$LOG_FILE" | wc -l | tr -d ' ')
+else
+    ENTRIES_TO_PROCESS=$(wc -l < "$LOG_FILE" | tr -d ' ')
+fi
+
+if [[ "$ENTRIES_TO_PROCESS" -eq 0 ]]; then
+    echo -e "${GREEN}Already up to date${NC}"
+    echo "No new entries to process."
+    exit 0
+fi
+
+echo -e "${CYAN}Entries to process:${NC} $ENTRIES_TO_PROCESS"
+
+# Process logs
+if [[ "$VERBOSE" == "true" ]]; then
+    echo ""
+    echo "Processing log entries..."
+fi
+
+NEW_DATA=$(_aggregate_logs "$CURSOR")
+PROCESSED=$(echo "$NEW_DATA" | jq -r '._entries_processed // 0')
+
+if [[ "$VERBOSE" == "true" ]]; then
+    echo "Processed $PROCESSED entries"
+fi
+
+# Merge or replace
+if [[ "$FULL_REBUILD" == "true" ]] || [[ "$CURSOR" == "" ]] || [[ "$CURSOR" == "null" ]]; then
+    # Full rebuild - use new data directly (remove internal field)
+    FINAL_USAGE=$(echo "$NEW_DATA" | jq 'del(._entries_processed)')
+else
+    # Incremental - merge with existing
+    FINAL_USAGE=$(_merge_usage "$EXISTING_USAGE" "$NEW_DATA")
+fi
+
+# Show summary
+echo ""
+echo "========================================"
+echo "Summary"
+echo "========================================"
+echo ""
+
+SKILL_COUNT=$(echo "$FINAL_USAGE" | jq '.skills | length')
+TOTAL_INVOCATIONS=$(echo "$FINAL_USAGE" | jq '.sessions.skill_invocations')
+TOTAL_SESSIONS=$(echo "$FINAL_USAGE" | jq '.sessions.total')
+NEW_CURSOR=$(echo "$FINAL_USAGE" | jq -r '.log_cursor // "none"')
+
+echo -e "${CYAN}Skills tracked:${NC}      $SKILL_COUNT"
+echo -e "${CYAN}Total invocations:${NC}  $TOTAL_INVOCATIONS"
+echo -e "${CYAN}Total sessions:${NC}     $TOTAL_SESSIONS"
+echo -e "${CYAN}New cursor:${NC}         $NEW_CURSOR"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo -e "${YELLOW}Dry run - no changes written${NC}"
+    if [[ "$VERBOSE" == "true" ]]; then
+        echo ""
+        echo "Would write:"
+        echo "$FINAL_USAGE" | jq .
+    fi
+    exit 0
+fi
+
+# Write usage.json
+mkdir -p "$TELEMETRY_DIR"
+echo "$FINAL_USAGE" | jq . > "$USAGE_FILE"
+
+echo ""
+echo -e "${GREEN}Aggregation complete${NC}"
+echo "Output: $USAGE_FILE"


### PR DESCRIPTION
## Summary

Creates the telemetry-aggregate skill to aggregate raw invocation logs into JSON tally format (usage.json):

- **Incremental mode**: processes only new entries using log_cursor
- **Full rebuild mode**: reprocesses all logs from scratch  
- **Dry-run mode**: preview changes without writing
- **Merges** new data with existing aggregations
- **Computes** period snapshots (7d, 30d)
- **Produces** usage.json matching the documented schema from #47

## Test plan

- [ ] Incremental aggregation processes new entries only
- [ ] Full rebuild recreates usage.json from scratch
- [ ] Cursor tracking prevents duplicate processing
- [ ] Merging combines old and new data correctly
- [ ] Handles empty logs gracefully

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)