### PR TITLE
feat: Instrument all toolkit skills with telemetry (dogfooding)

### DIFF
--- a/templates/skills/address-review.sh.template
+++ b/templates/skills/address-review.sh.template
@@ -115,6 +115,22 @@ _get_repo_info
 # END MODE DETECTION
 # ============================================================================
 
+# ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
 PR_NUMBER="${1:-}"
 
 if [[ -z "$PR_NUMBER" ]]; then

--- a/templates/skills/check-reviews.sh.template
+++ b/templates/skills/check-reviews.sh.template
@@ -132,6 +132,22 @@ _get_repo_info
 # END MODE DETECTION
 # ============================================================================
 
+# ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
 # Toolkit update check (silent unless updates available)
 _check_toolkit_updates() {
     local toolkit_dir="${TOOLKIT_SOURCE:-${HOME}/claude-workflow-toolkit}"

--- a/templates/skills/check-workflow.sh.template
+++ b/templates/skills/check-workflow.sh.template
@@ -122,6 +122,22 @@ _get_repo_info
 # END MODE DETECTION
 # ============================================================================
 
+# ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/templates/skills/claim-issue.sh.template
+++ b/templates/skills/claim-issue.sh.template
@@ -115,6 +115,22 @@ _get_repo_info
 # END MODE DETECTION
 # ============================================================================
 
+# ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/templates/skills/review-pr.sh.template
+++ b/templates/skills/review-pr.sh.template
@@ -99,6 +99,22 @@ _detect_mode
 _get_repo_info
 
 # ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
+# ============================================================================
 # CONFIGURATION
 # ============================================================================
 

--- a/templates/skills/submit-pr.sh.template
+++ b/templates/skills/submit-pr.sh.template
@@ -115,6 +115,22 @@ _get_repo_info
 # END MODE DETECTION
 # ============================================================================
 
+# ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/templates/skills/sync-skills.sh.template
+++ b/templates/skills/sync-skills.sh.template
@@ -54,6 +54,22 @@ _detect_mode() {
 _detect_mode
 
 # ============================================================================
+# TELEMETRY
+# ============================================================================
+
+_init_telemetry() {
+    local telemetry_lib="${SCRIPT_DIR}/../../lib/telemetry.sh"
+    if [[ -f "$telemetry_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$telemetry_lib"
+        telemetry_start "$(basename "$0")"
+        return 0
+    fi
+    return 1
+}
+_init_telemetry 2>/dev/null || true
+
+# ============================================================================
 # MAIN
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Adds telemetry instrumentation to all core workflow skills:

- `address-review`
- `check-reviews`  
- `check-workflow`
- `claim-issue`
- `review-pr`
- `submit-pr`
- `sync-skills`

### Each skill now:
- Sources `lib/telemetry.sh` at startup (if available)
- Calls `telemetry_start` with skill name
- Logs invocations automatically via EXIT trap
- Fails silently if telemetry lib not present (graceful degradation)

### Enables:
- Usage tracking during toolkit development
- PR cycle analysis (claim → implement → submit)
- Quality gate failure detection
- Skill usage patterns insight

### Notes:
- Worker was already instrumented in #49
- Telemetry skills don't track themselves (avoid recursion)

## Test plan

- [ ] Skills run normally without telemetry lib
- [ ] With lib present, invocations logged
- [ ] No performance regression
- [ ] No token overhead (AI unaware)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)