### PR TITLE
feat: Expand /sync-skills to full toolkit sync with CLAUDE.md marker merge

### DIFF
--- a/scripts/bootstrap-workspace.sh
+++ b/scripts/bootstrap-workspace.sh
@@ -249,28 +249,13 @@ CONFIGEOF
     echo -e "  ${GREEN}✓${NC} workspace-config"
 fi
 
-# Install skills
+# Install everything via --full
 echo ""
-echo "Installing skills..."
+echo "Installing toolkit (skills, CLAUDE.md, roles, docs)..."
 if $DRY_RUN; then
-    "$TOOLKIT_DIR/scripts/install-skill.sh" --all --target "$WORKSPACE_PATH" --profile "$PROFILE_NAME" --dry-run
+    "$TOOLKIT_DIR/scripts/install-skill.sh" --full --target "$WORKSPACE_PATH" --profile "$PROFILE_NAME" --update --dry-run
 else
-    "$TOOLKIT_DIR/scripts/install-skill.sh" --all --target "$WORKSPACE_PATH" --profile "$PROFILE_NAME"
-fi
-
-# Install CLAUDE.md
-echo ""
-echo "Installing CLAUDE.md..."
-if $DRY_RUN; then
-    "$TOOLKIT_DIR/scripts/install-skill.sh" worker --target "$WORKSPACE_PATH" --with-claude-md --dry-run 2>/dev/null | grep -A1 "CLAUDE.md" || echo -e "  ${BLUE}→${NC} CLAUDE.md"
-else
-    "$TOOLKIT_DIR/scripts/install-skill.sh" worker --target "$WORKSPACE_PATH" --with-claude-md 2>/dev/null | grep -A1 "CLAUDE.md" || true
-    # Ensure CLAUDE.md has correct repo info
-    if [[ -f "$WORKSPACE_PATH/CLAUDE.md" ]]; then
-        sed -i "s/{{REPO_OWNER}}/$REPO_OWNER/g" "$WORKSPACE_PATH/CLAUDE.md" 2>/dev/null || true
-        sed -i "s/{{REPO_NAME}}/$REPO_NAME/g" "$WORKSPACE_PATH/CLAUDE.md" 2>/dev/null || true
-        echo -e "  ${GREEN}✓${NC} CLAUDE.md"
-    fi
+    "$TOOLKIT_DIR/scripts/install-skill.sh" --full --target "$WORKSPACE_PATH" --profile "$PROFILE_NAME" --update
 fi
 
 # Summary

--- a/templates/.claude/commands/sync-skills.md.template
+++ b/templates/.claude/commands/sync-skills.md.template
@@ -1,17 +1,17 @@
 ---
 name: sync-skills
-description: Update all workspace skills from toolkit templates
-version: 1.0.0
+description: Sync all toolkit-managed files from templates
+version: 2.0.0
 ---
 
 # /sync-skills
 
-Updates all skills in the current workspace from the toolkit's template files.
+Syncs all toolkit-managed files to the current workspace from template sources.
 
 ## Usage
 
 ```bash
-/sync-skills [--dry-run]
+/sync-skills [--dry-run] [--skills-only]
 ```
 
 ## Options
@@ -19,18 +19,53 @@ Updates all skills in the current workspace from the toolkit's template files.
 | Option | Description |
 |--------|-------------|
 | `--dry-run` | Show what would be updated without making changes |
+| `--skills-only` | Only sync skill scripts and command docs (legacy behavior) |
 
-## What It Does
+## What It Syncs
 
-1. Locates the toolkit source (via `TOOLKIT_SOURCE` config or default paths)
-2. Runs `install-skill.sh --all --update` to update all skills
-3. Reports which skills were updated
+### Always Overwritten (toolkit-managed)
+
+| File | Source |
+|------|--------|
+| `.claude/skills/*` | Skill scripts from templates |
+| `.claude/commands/*` | Command docs from templates |
+| `.claude/WORKER-ROLE.md` | Worker agent role definition |
+| `.claude/SECURITY-CHECKLIST.md` | Security checklist from profile |
+| `.claude/toolkit-version` | Regenerated with current commit/date |
+| `.codex/skills` | Symlink to `.claude/skills` |
+
+### Marker-Based Merge
+
+| File | Behavior |
+|------|----------|
+| `CLAUDE.md` | Content between `<!-- TOOLKIT:BEGIN -->` / `<!-- TOOLKIT:END -->` is replaced; user content outside markers is preserved |
+
+### Create-If-Missing (never overwritten)
+
+| File | Description |
+|------|-------------|
+| `WORKSPACE.md` | Workspace description (workspace mode only) |
+| `.claude/docs/QUICK-REFERENCE.md` | Command reference |
+| `.claude/docs/FAQ-AGENTS.md` | Common questions |
+| `.claude/docs/CODEBASE-MAP.md` | Codebase overview |
+
+## CLAUDE.md Marker Merge
+
+The toolkit uses HTML comment markers to manage its section of `CLAUDE.md`:
+
+| Scenario | Behavior |
+|----------|----------|
+| File doesn't exist | Created with markers |
+| File has markers | Content between markers replaced, rest preserved |
+| File exists, no markers, `--update` | Toolkit section prepended |
+| File exists, no markers, no `--update` | Skipped |
 
 ## When to Use
 
 - After pulling toolkit updates that include template changes
 - When validation shows outdated skills
 - After fixing a bug in a skill template
+- To ensure all toolkit files are present
 
 ## Configuration
 
@@ -46,7 +81,7 @@ The skill looks for the toolkit source in this order:
 $ /sync-skills
 
 ========================================
-Syncing Skills from Toolkit
+Syncing Toolkit
 ========================================
 Toolkit: /home/user/claude-workflow-toolkit
 Target:  /home/user/workspaces/myproject
@@ -60,9 +95,23 @@ Installing skills...
   ✓ worker
   ...
 
-Done! 6 skill(s) processed
+Installing toolkit files...
+  ✓ .claude/WORKER-ROLE.md
+  ✓ .claude/SECURITY-CHECKLIST.md
+  ✓ .claude/toolkit-version
+  ✓ .codex/skills (symlink exists)
 
-Skills synchronized!
+Installing CLAUDE.md...
+  ✓ CLAUDE.md (markers updated, user content preserved)
+
+Installing docs (create-if-missing)...
+  ⊘ .claude/docs/QUICK-REFERENCE.md (exists, preserved)
+  ✓ .claude/docs/FAQ-AGENTS.md
+  ⊘ WORKSPACE.md (exists, preserved)
+
+Done! 10 skill(s) processed
+
+Toolkit synchronized!
 ```
 
 ## Related
@@ -71,4 +120,4 @@ Skills synchronized!
 |-------|--------------|
 | `/worker` | May show validation warnings if skills outdated |
 | `validate-toolkit.sh` | Checks for outdated skills |
-| `install-skill.sh` | Called internally to install skills |
+| `install-skill.sh` | Called internally with `--full` flag |

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -1,3 +1,4 @@
+<!-- TOOLKIT:BEGIN -->
 # Claude Code Instructions
 
 This workspace uses **claude-workflow-toolkit** for structured development.
@@ -117,3 +118,4 @@ For multi-step tasks, state a brief plan:
 2. [Step] → verify: [check]
 3. [Step] → verify: [check]
 ```
+<!-- TOOLKIT:END -->

--- a/templates/skills/sync-skills.sh.template
+++ b/templates/skills/sync-skills.sh.template
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Skill: /sync-skills
-# Description: Update all workspace skills from toolkit templates
-# Usage: /sync-skills [--dry-run]
+# Description: Sync all toolkit-managed files (skills, CLAUDE.md, roles, docs)
+# Usage: /sync-skills [--dry-run] [--skills-only]
 
 set -euo pipefail
 
@@ -13,12 +13,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TARGET_PROJECT=""
 MODE=""
 DRY_RUN=false
+SKILLS_ONLY=false
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run|-n)
             DRY_RUN=true
+            shift
+            ;;
+        --skills-only)
+            SKILLS_ONLY=true
             shift
             ;;
         *)
@@ -81,7 +86,11 @@ NC='\033[0m'
 
 echo ""
 echo "========================================"
-echo -e "${BLUE}Syncing Skills from Toolkit${NC}"
+if $SKILLS_ONLY; then
+    echo -e "${BLUE}Syncing Skills from Toolkit${NC}"
+else
+    echo -e "${BLUE}Syncing Toolkit${NC}"
+fi
 echo "========================================"
 
 # Find toolkit source
@@ -127,11 +136,24 @@ if [[ ! -x "$INSTALL_SCRIPT" ]]; then
     exit 1
 fi
 
-if $DRY_RUN; then
-    "$INSTALL_SCRIPT" --all --target "$TARGET" --update --dry-run
+# Build command flags
+INSTALL_FLAGS=("--target" "$TARGET" "--update")
+
+if $SKILLS_ONLY; then
+    INSTALL_FLAGS=("--all" "${INSTALL_FLAGS[@]}")
 else
-    "$INSTALL_SCRIPT" --all --target "$TARGET" --update
+    INSTALL_FLAGS=("--full" "${INSTALL_FLAGS[@]}")
 fi
 
+if $DRY_RUN; then
+    INSTALL_FLAGS+=("--dry-run")
+fi
+
+"$INSTALL_SCRIPT" "${INSTALL_FLAGS[@]}"
+
 echo ""
-echo -e "${GREEN}Skills synchronized!${NC}"
+if $SKILLS_ONLY; then
+    echo -e "${GREEN}Skills synchronized!${NC}"
+else
+    echo -e "${GREEN}Toolkit synchronized!${NC}"
+fi


### PR DESCRIPTION
## Summary

- Adds `--full` flag to `install-skill.sh` that syncs all toolkit-managed files: skills, WORKER-ROLE.md, SECURITY-CHECKLIST.md, toolkit-version, codex symlink, CLAUDE.md (marker merge), and docs
- Implements marker-based merge for CLAUDE.md using `<!-- TOOLKIT:BEGIN/END -->` markers that preserves user content outside the toolkit section
- Adds `--skills-only` flag to `/sync-skills` for legacy behavior; default is now full sync
- Simplifies `bootstrap-workspace.sh` to a single `--full` call, removing hacky sed fixup

## Test plan

- [x] `install-skill.sh --full --dry-run` lists all files (skills, roles, docs, CLAUDE.md, toolkit-version)
- [x] Full sync creates CLAUDE.md with markers, all toolkit files installed
- [x] Re-run is idempotent: markers replaced cleanly, create-if-missing files skipped
- [x] User content above/below markers is preserved on re-sync
- [x] `--skills-only` / `--all` without `--full` gives legacy skills-only behavior
- [x] `bootstrap-workspace.sh --dry-run` uses single `--full` call, creates all files

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)